### PR TITLE
Users | Authentication for Admin|Developer|Customer

### DIFF
--- a/backend/users/backend/administrator/models.py
+++ b/backend/users/backend/administrator/models.py
@@ -39,8 +39,8 @@ class AdminGroup(BaseGroup):
         AdminPermission,
         verbose_name=_("permission"),
         blank=True,
-        related_name='admingroup_set',
-        related_query_name='admingroup',
+        related_name="admingroup_set",
+        related_query_name="admingroup",
     )
 
     class Meta(BaseGroup.Meta):
@@ -76,7 +76,7 @@ class Admin(BaseAbstractUser, AdminPermissionMixin):
     is_superuser = models.BooleanField(default=False)
     country = models.ForeignKey(
         Country,
-        verbose_name=_('admin country'),
+        verbose_name=_("admin country"),
         on_delete=models.SET_NULL,
         null=True,
     )
@@ -116,6 +116,12 @@ class Admin(BaseAbstractUser, AdminPermissionMixin):
         related_name="admin_set",
         related_query_name="admin",
     )
+
+    @property
+    def permissions_codename(self) -> list[str]:
+        return list(self.user_permissions.values_list("codename", flat=True)) + list(
+            self.developer_permissions.values_list("codename", flat=True)
+        )
 
     objects = AdminManager()
 

--- a/backend/users/backend/administrator/serializers/v1/auth_serializer.py
+++ b/backend/users/backend/administrator/serializers/v1/auth_serializer.py
@@ -1,0 +1,8 @@
+from administrator.models import Admin
+from base.serializers import BaseAuthSerializer
+
+
+class AdminAuthSerializer(BaseAuthSerializer):
+    class Meta:
+        model = Admin
+        fields = ("email", "password")

--- a/backend/users/backend/administrator/tests/test_auth_view.py
+++ b/backend/users/backend/administrator/tests/test_auth_view.py
@@ -1,0 +1,51 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+
+from administrator.models import Admin
+
+
+class AdminAuthViewTestCase(APITestCase):
+    def setUp(self):
+        self.url = reverse("admin_login")
+
+    def test_admin_authentication_success(self):
+        """
+        Отправляем POST-запрос на аутентификацию с валидными учетными данными
+        """
+
+        Admin.objects.create_user(
+            username="testuser",
+            password="password",
+            email="test@example.com",
+            phone="9998887766",
+        )
+
+        data = {"email": "test@example.com", "password": "password"}
+
+        response = self.client.post(self.url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertIn("access", response.data)
+        self.assertIn("refresh", response.data)
+
+    def test_admin_authentication_invalid_credentials(self):
+        """
+        Отправляем POST-запрос на аутентификацию с неправильными учетными данными
+        """
+        data = {"username": "testuser", "password": "wrongpassword"}
+        response = self.client.post(self.url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_admin_authentication_missing_fields(self):
+        """
+        Отправляем POST-запрос на аутентификацию без указания обязательных полей
+        """
+
+        data = {}
+
+        response = self.client.post(self.url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/backend/users/backend/administrator/urls.py
+++ b/backend/users/backend/administrator/urls.py
@@ -7,37 +7,45 @@ from administrator.views.v1.employee_crud import (
     EmployeeDetailView,
     EmployeeSendEmail,
 )
+from administrator.views.v1.auth_view import AdminAuthView
 
 router = routers.DefaultRouter()
-router.register(r'group', AdminGroupViewSet, basename='admin_group')
-router.register(r'permission', AdminPermissionViewSet, basename='admin_permission')
+router.register(r"group", AdminGroupViewSet, basename="admin_group")
+router.register(r"permission", AdminPermissionViewSet, basename="admin_permission")
 
 urlpatterns = router.urls
 
 account_router = [
     path(
-        'administrator/me',
+        "administrator/me",
         account_views.AccountViewSet.as_view(
-            {'get': 'retrieve', 'put': 'partial_update', 'delete': 'destroy'}
+            {"get": "retrieve", "put": "partial_update", "delete": "destroy"}
         ),
-        name='administrator-user-account',
+        name="administrator-user-account",
     ),
     path(
-        'administrator/me/change-password',
-        account_views.ChangePasswordViewSet.as_view({'post': 'create'}),
-        name='admininstrator-user-change-password',
+        "administrator/me/change-password",
+        account_views.ChangePasswordViewSet.as_view({"post": "create"}),
+        name="admininstrator-user-change-password",
     ),
 ]
 
 generic_urls = [
-    path('employee/', EmployeeListView.as_view(), name='admin_employee'),
-    path('employee/<uuid:pk>/', EmployeeDetailView.as_view(), name='admin_employee_detail'),
+    path("employee/", EmployeeListView.as_view(), name="admin_employee"),
     path(
-        'employee/<uuid:pk>/send_email/',
+        "employee/<uuid:pk>/",
+        EmployeeDetailView.as_view(),
+        name="admin_employee_detail",
+    ),
+    path(
+        "employee/<uuid:pk>/send_email/",
         EmployeeSendEmail.as_view(),
-        name='admin_employee_send_email',
+        name="admin_employee_send_email",
     ),
 ]
 
+auth_urls = [path("login/", AdminAuthView.as_view(), name="admin_login")]
+
 urlpatterns += account_router
 urlpatterns += generic_urls
+urlpatterns += auth_urls

--- a/backend/users/backend/administrator/views/v1/auth_view.py
+++ b/backend/users/backend/administrator/views/v1/auth_view.py
@@ -1,3 +1,5 @@
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView, Response
@@ -9,6 +11,28 @@ from common.services.jwt.token import Token
 class AdminAuthView(APIView):
     permission_classes = [AllowAny]
 
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "email": openapi.Schema(type=openapi.TYPE_STRING),
+                "password": openapi.Schema(type=openapi.TYPE_STRING),
+            },
+            required=["email", "password"],
+        ),
+        responses={
+            200: openapi.Response(
+                description="Successful authentication",
+                schema=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        "tokens": openapi.Schema(type=openapi.TYPE_STRING),
+                    },
+                ),
+            ),
+            400: openapi.Response(description="Email or Password not valid"),
+        },
+    )
     def post(self, request):
         serializer = AdminAuthSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/backend/users/backend/administrator/views/v1/auth_view.py
+++ b/backend/users/backend/administrator/views/v1/auth_view.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView, Response
 from administrator.serializers.v1.auth_serializer import AdminAuthSerializer
+from base.serializers import AuthTokensResponseSerializer
 
 from common.services.jwt.token import Token
 
@@ -12,24 +13,9 @@ class AdminAuthView(APIView):
     permission_classes = [AllowAny]
 
     @swagger_auto_schema(
-        request_body=openapi.Schema(
-            type=openapi.TYPE_OBJECT,
-            properties={
-                "email": openapi.Schema(type=openapi.TYPE_STRING),
-                "password": openapi.Schema(type=openapi.TYPE_STRING),
-            },
-            required=["email", "password"],
-        ),
+        request_body=AdminAuthSerializer,
         responses={
-            200: openapi.Response(
-                description="Successful authentication",
-                schema=openapi.Schema(
-                    type=openapi.TYPE_OBJECT,
-                    properties={
-                        "tokens": openapi.Schema(type=openapi.TYPE_STRING),
-                    },
-                ),
-            ),
+            200: AuthTokensResponseSerializer,
             400: openapi.Response(description="Email or Password not valid"),
         },
     )
@@ -47,4 +33,7 @@ class AdminAuthView(APIView):
 
         tokens = Token().generate_tokens(data=data)
 
-        return Response(tokens, status=status.HTTP_200_OK)
+        response_serializer = AuthTokensResponseSerializer(data=tokens)
+        response_serializer.is_valid(raise_exception=True)
+
+        return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/backend/users/backend/administrator/views/v1/auth_view.py
+++ b/backend/users/backend/administrator/views/v1/auth_view.py
@@ -1,0 +1,26 @@
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.views import APIView, Response
+from administrator.serializers.v1.auth_serializer import AdminAuthSerializer
+
+from common.services.jwt.token import Token
+
+
+class AdminAuthView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        serializer = AdminAuthSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        admin = serializer.validated_data["user"]
+        data = {
+            "user_id": str(admin.id),
+            "role": admin._meta.app_label,
+            "avatar": str(admin.avatar),
+            "permissions": admin.permissions_codename,
+        }
+
+        tokens = Token().generate_tokens(data=data)
+
+        return Response(tokens, status=status.HTTP_200_OK)

--- a/backend/users/backend/administrator/views/v1/auth_view.py
+++ b/backend/users/backend/administrator/views/v1/auth_view.py
@@ -18,6 +18,7 @@ class AdminAuthView(APIView):
             200: AuthTokensResponseSerializer,
             400: openapi.Response(description="Email or Password not valid"),
         },
+        tags=["Аутентификация Admin"],
     )
     def post(self, request):
         serializer = AdminAuthSerializer(data=request.data)

--- a/backend/users/backend/base/base_tests/test_base_auth_serializer.py
+++ b/backend/users/backend/base/base_tests/test_base_auth_serializer.py
@@ -1,0 +1,60 @@
+from django.test import TestCase
+from rest_framework.exceptions import ValidationError
+from administrator.models import Admin
+
+from base.serializers import BaseAuthSerializer
+
+
+class BaseAuthSerializerTestCase(TestCase):
+    def setUp(self):
+        self.admin_user = Admin.objects.create_superuser(
+            "admin", "admin@example.com", "adminpassword", "9998887766", is_active=True
+        )
+
+    def test_valid_credentials(self):
+        data = {"email": "admin@example.com", "password": "adminpassword"}
+        serializer = BaseAuthSerializer(data=data)
+        serializer.Meta.model = Admin
+        serializer.is_valid(raise_exception=True)
+        self.assertEqual(serializer.validated_data["user"], self.admin_user)
+
+    def test_invalid_email(self):
+        data = {"email": "invalid@example.com", "password": "adminpassword"}
+        serializer = BaseAuthSerializer(data=data)
+        serializer.Meta.model = Admin
+        with self.assertRaises(ValidationError) as cm:
+            serializer.is_valid(raise_exception=True)
+        error_detail = cm.exception.detail["non_field_errors"][0]
+        self.assertEqual(error_detail, "Email or Password not valid")
+
+    def test_invalid_password(self):
+        data = {"email": "admin@example.com", "password": "wrongpassword"}
+        serializer = BaseAuthSerializer(data=data)
+        serializer.Meta.model = Admin
+        with self.assertRaises(ValidationError) as cm:
+            serializer.is_valid(raise_exception=True)
+
+        error_detail = cm.exception.detail["non_field_errors"][0]
+        self.assertEqual(error_detail, "Email or Password not valid")
+
+    def test_inactive_user(self):
+        self.admin_user.is_active = False
+        self.admin_user.save()
+        data = {"email": "admin@example.com", "password": "adminpassword"}
+        serializer = BaseAuthSerializer(data=data)
+        serializer.Meta.model = Admin
+        with self.assertRaises(ValidationError) as cm:
+            serializer.is_valid(raise_exception=True)
+        error_detail = cm.exception.detail["non_field_errors"][0]
+        self.assertEqual(error_detail, "Inactive user")
+
+    def test_banned_user(self):
+        self.admin_user.is_banned = True
+        self.admin_user.save()
+        data = {"email": "admin@example.com", "password": "adminpassword"}
+        serializer = BaseAuthSerializer(data=data)
+        serializer.Meta.model = Admin
+        with self.assertRaises(ValidationError) as cm:
+            serializer.is_valid(raise_exception=True)
+        error_detail = cm.exception.detail["non_field_errors"][0]
+        self.assertEqual(error_detail, "User is banned")

--- a/backend/users/backend/base/models.py
+++ b/backend/users/backend/base/models.py
@@ -27,10 +27,6 @@ class BaseAbstractUser(AbstractUser):
 
     REQUIRED_FIELDS = ["phone", "email"]
 
-    @property
-    def permissions_codename(self) -> list[str]:
-        return list(self.user_permissions.values_list("codename", flat=True))
-
     class Meta:
         abstract = True
 

--- a/backend/users/backend/base/models.py
+++ b/backend/users/backend/base/models.py
@@ -14,7 +14,7 @@ from django.db import models
 class BaseAbstractUser(AbstractUser):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     email = models.EmailField(_("email address"), unique=True, db_index=True)
-    phone = models.CharField(_("phone"), max_length=15, unique=True, default='')
+    phone = models.CharField(_("phone"), max_length=15, unique=True, default="")
     is_banned = models.BooleanField(default=False)
     created_at = models.DateTimeField(_("user creation date"), auto_now_add=True)
     update_at = models.DateTimeField(_("user modify date"), auto_now=True)
@@ -25,7 +25,11 @@ class BaseAbstractUser(AbstractUser):
     date_joined = None  # Remove data joined field
     last_login = None  # Remove last login field
 
-    REQUIRED_FIELDS = ['phone', 'email']
+    REQUIRED_FIELDS = ["phone", "email"]
+
+    @property
+    def permissions_codename(self) -> list[str]:
+        return list(self.user_permissions.values_list("codename", flat=True))
 
     class Meta:
         abstract = True

--- a/backend/users/backend/base/serializers.py
+++ b/backend/users/backend/base/serializers.py
@@ -1,21 +1,24 @@
 from django.contrib.auth.password_validation import validate_password
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.exceptions import ParseError
+from rest_framework.fields import ValidationError
 from rest_framework.serializers import ModelSerializer
-from base.models import BasePermission, BaseGroup
+from common.permissions.validators import ActiveUserValidator, BannedUserValidatorVerify
+from base.models import BaseAbstractUser, BasePermission, BaseGroup
 
 
 class BasePermissionSerializer(ModelSerializer):
     class Meta:
         model = BasePermission
-        fields = ['name', 'codename']
+        fields = ["name", "codename"]
         abstract = True
 
 
 class BaseGroupSerializer(ModelSerializer):
     class Meta:
         model = BaseGroup
-        fields = ['name', 'permission']
+        fields = ["name", "permission"]
         abstract = True
 
 
@@ -25,10 +28,10 @@ class ChangePasswordSerializers(serializers.ModelSerializer):
     confirmation_new_password = serializers.CharField(write_only=True)
 
     def validate(self, attrs):
-        user = self.context['request'].user
-        old_password = attrs.pop('old_password')
+        user = self.context["request"].user
+        old_password = attrs.pop("old_password")
         if not user.check_password(old_password):
-            raise ParseError('Please check that your current password is correct')
+            raise ParseError("Please check that your current password is correct")
         self.valid_confirm_password(attrs)
         return attrs
 
@@ -38,15 +41,35 @@ class ChangePasswordSerializers(serializers.ModelSerializer):
 
     @staticmethod
     def valid_confirm_password(attrs):
-        new_password = attrs.get('new_password')
-        confirmation_new_password = attrs.get('confirmation_new_password')
+        new_password = attrs.get("new_password")
+        confirmation_new_password = attrs.get("confirmation_new_password")
         if not new_password == confirmation_new_password:
-            raise ParseError('The confirmation password does not match the new password')
+            raise ParseError("The confirmation password does not match the new password")
         return attrs
 
     def create(self, validate_data):
-        password = validate_data.pop('new_password')
-        instance = self.context['request'].user
+        password = validate_data.pop("new_password")
+        instance = self.context["request"].user
         instance.set_password(password)
         instance.save()
         return instance
+
+
+class BaseAuthSerializer(serializers.ModelSerializer):
+    email = serializers.EmailField()
+
+    def validate(self, attrs):
+        if not self.Meta.model.objects.filter(email=attrs["email"]).exists():
+            raise ValidationError(_("Email or Password not valid"))
+        user = self.Meta.model.objects.get(email=attrs["email"])
+
+        if not user.check_password(attrs["password"]):
+            raise ValidationError(_("Email or Password not valid"))
+        ActiveUserValidator(_("Inactive user")).validate(user)
+        BannedUserValidatorVerify(_("User is banned")).validate(user)
+        attrs["user"] = user
+        return attrs
+
+    class Meta:
+        model: BaseAbstractUser
+        fields = ("email", "password")

--- a/backend/users/backend/base/serializers.py
+++ b/backend/users/backend/base/serializers.py
@@ -73,3 +73,8 @@ class BaseAuthSerializer(serializers.ModelSerializer):
     class Meta:
         model: BaseAbstractUser
         fields = ("email", "password")
+
+
+class AuthTokensResponseSerializer(serializers.Serializer):
+    access = serializers.CharField()
+    refresh = serializers.CharField()

--- a/backend/users/backend/customer/models.py
+++ b/backend/users/backend/customer/models.py
@@ -1,3 +1,4 @@
+from datetime import date
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import UserManager
 from django.core.exceptions import ValidationError
@@ -23,18 +24,21 @@ class CustomerManager(UserManager):
         return self._create_customer_user(username, email, phone, password, **extra_fields)
 
     def create_superuser(self, username, email=None, phone=None, password=None, **extra_fields):
-        raise ValidationError(_('unable to create a superuser'))
+        raise ValidationError(_("unable to create a superuser"))
 
 
 class CustomerUser(BaseAbstractUser):
     friends = models.ManyToManyField(
-        'self', symmetrical=True, through='FriendShipRequest', through_fields=('sender', 'receiver')
+        "self",
+        symmetrical=True,
+        through="FriendShipRequest",
+        through_fields=("sender", "receiver"),
     )
     birthday = models.DateField(_("customer birthday"))
     avatar = models.ImageField(null=True, blank=True)
     is_active = models.BooleanField(default=False)
     country = models.ForeignKey(
-        Country, verbose_name='Страна', on_delete=models.SET_NULL, null=True
+        Country, verbose_name="Страна", on_delete=models.SET_NULL, null=True
     )
 
     groups = None
@@ -42,20 +46,36 @@ class CustomerUser(BaseAbstractUser):
 
     objects = CustomerManager()
 
+    @property
+    def age(self) -> int:
+        today: date = date.today()
+        age: int = today.year - self.birthday.year
+
+        if today.month < self.birthday.month or (
+            today.month == self.birthday.month and today.day < self.birthday.day
+        ):
+            age -= 1
+
+        return age
+
     class Meta:
-        db_table = 'customer'
+        db_table = "customer"
 
 
 class FriendShipRequest(models.Model):
-    REQUESTED = 'REQUESTED'  # запрошен
-    ACCEPTED = 'ACCEPTED'  # принято
-    REJECTED = 'REJECTED'  # отклонен
+    REQUESTED = "REQUESTED"  # запрошен
+    ACCEPTED = "ACCEPTED"  # принято
+    REJECTED = "REJECTED"  # отклонен
 
-    STATUS_CHOICES = ((REQUESTED, 'requested'), (ACCEPTED, 'accepted'), (REJECTED, 'rejected'))
+    STATUS_CHOICES = (
+        (REQUESTED, "requested"),
+        (ACCEPTED, "accepted"),
+        (REJECTED, "rejected"),
+    )
     status = models.TextField(choices=STATUS_CHOICES, default=REQUESTED)
     sender = models.ForeignKey(
-        CustomerUser, on_delete=models.CASCADE, related_name='sender'
+        CustomerUser, on_delete=models.CASCADE, related_name="sender"
     )  # отправитель
     receiver = models.ForeignKey(
-        CustomerUser, on_delete=models.CASCADE, related_name='receiver'
+        CustomerUser, on_delete=models.CASCADE, related_name="receiver"
     )  # получатель

--- a/backend/users/backend/customer/serializers/v1/auth_serializer.py
+++ b/backend/users/backend/customer/serializers/v1/auth_serializer.py
@@ -1,0 +1,8 @@
+from base.serializers import BaseAuthSerializer
+from customer.models import CustomerUser
+
+
+class CustomerAuthSerializer(BaseAuthSerializer):
+    class Meta:
+        model = CustomerUser
+        fields = ("email", "password")

--- a/backend/users/backend/customer/urls.py
+++ b/backend/users/backend/customer/urls.py
@@ -1,25 +1,29 @@
 from django.urls import path
+from customer.views.v1.auth_view import CustomerAuthView
 from customer.views.v1 import account_views
 from customer.views.v1.customer_registration_view import CustomerRegistrationView
 
 
 urlpatterns = [
-    path('registration/', CustomerRegistrationView.as_view()),
+    path("registration/", CustomerRegistrationView.as_view()),
 ]
 
 account_router = [
     path(
-        'customer/me',
+        "customer/me",
         account_views.AccountViewSet.as_view(
-            {'get': 'retrieve', 'put': 'partial_update', 'delete': 'destroy'}
+            {"get": "retrieve", "put": "partial_update", "delete": "destroy"}
         ),
-        name='customer-user-account',
+        name="customer-user-account",
     ),
     path(
-        'customer/me/change-password',
-        account_views.ChangePasswordViewSet.as_view({'post': 'create'}),
-        name='customer-user-change-password',
+        "customer/me/change-password",
+        account_views.ChangePasswordViewSet.as_view({"post": "create"}),
+        name="customer-user-change-password",
     ),
 ]
 
+auth_routes = [path("login/", CustomerAuthView.as_view(), name="customer_login")]
+
 urlpatterns += account_router
+urlpatterns += auth_routes

--- a/backend/users/backend/customer/views/v1/auth_view.py
+++ b/backend/users/backend/customer/views/v1/auth_view.py
@@ -18,7 +18,6 @@ class CustomerAuthView(APIView):
             "user_id": str(customer.id),
             "role": customer._meta.app_label,
             "avatar": str(customer.avatar),
-            "permissions": customer.permissions_codename,
             "age": customer.age,
         }
 

--- a/backend/users/backend/customer/views/v1/auth_view.py
+++ b/backend/users/backend/customer/views/v1/auth_view.py
@@ -1,3 +1,5 @@
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView, Response
@@ -9,6 +11,28 @@ from common.services.jwt.token import Token
 class CustomerAuthView(APIView):
     permission_classes = [AllowAny]
 
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "email": openapi.Schema(type=openapi.TYPE_STRING),
+                "password": openapi.Schema(type=openapi.TYPE_STRING),
+            },
+            required=["email", "password"],
+        ),
+        responses={
+            200: openapi.Response(
+                description="Successful authentication",
+                schema=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        "tokens": openapi.Schema(type=openapi.TYPE_STRING),
+                    },
+                ),
+            ),
+            400: openapi.Response(description="Email or Password not valid"),
+        },
+    )
     def post(self, request):
         serializer = CustomerAuthSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -22,5 +46,4 @@ class CustomerAuthView(APIView):
         }
 
         tokens = Token().generate_tokens(data=data)
-
         return Response(tokens, status=status.HTTP_200_OK)

--- a/backend/users/backend/customer/views/v1/auth_view.py
+++ b/backend/users/backend/customer/views/v1/auth_view.py
@@ -1,0 +1,27 @@
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.views import APIView, Response
+from customer.serializers.v1.auth_serializer import CustomerAuthSerializer
+
+from common.services.jwt.token import Token
+
+
+class CustomerAuthView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        serializer = CustomerAuthSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        customer = serializer.validated_data["user"]
+        data = {
+            "user_id": str(customer.id),
+            "role": customer._meta.app_label,
+            "avatar": str(customer.avatar),
+            "permissions": customer.permissions_codename,
+            "age": customer.age,
+        }
+
+        tokens = Token().generate_tokens(data=data)
+
+        return Response(tokens, status=status.HTTP_200_OK)

--- a/backend/users/backend/customer/views/v1/auth_view.py
+++ b/backend/users/backend/customer/views/v1/auth_view.py
@@ -18,6 +18,7 @@ class CustomerAuthView(APIView):
             200: AuthTokensResponseSerializer,
             400: openapi.Response(description="Email or Password not valid"),
         },
+        tags=["Аутентификация Customer"],
     )
     def post(self, request):
         serializer = CustomerAuthSerializer(data=request.data)

--- a/backend/users/backend/customer/views/v1/auth_view.py
+++ b/backend/users/backend/customer/views/v1/auth_view.py
@@ -3,6 +3,7 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView, Response
+from base.serializers import AuthTokensResponseSerializer
 from customer.serializers.v1.auth_serializer import CustomerAuthSerializer
 
 from common.services.jwt.token import Token
@@ -12,24 +13,9 @@ class CustomerAuthView(APIView):
     permission_classes = [AllowAny]
 
     @swagger_auto_schema(
-        request_body=openapi.Schema(
-            type=openapi.TYPE_OBJECT,
-            properties={
-                "email": openapi.Schema(type=openapi.TYPE_STRING),
-                "password": openapi.Schema(type=openapi.TYPE_STRING),
-            },
-            required=["email", "password"],
-        ),
+        request_body=CustomerAuthSerializer,
         responses={
-            200: openapi.Response(
-                description="Successful authentication",
-                schema=openapi.Schema(
-                    type=openapi.TYPE_OBJECT,
-                    properties={
-                        "tokens": openapi.Schema(type=openapi.TYPE_STRING),
-                    },
-                ),
-            ),
+            200: AuthTokensResponseSerializer,
             400: openapi.Response(description="Email or Password not valid"),
         },
     )
@@ -46,4 +32,8 @@ class CustomerAuthView(APIView):
         }
 
         tokens = Token().generate_tokens(data=data)
-        return Response(tokens, status=status.HTTP_200_OK)
+
+        response_serializer = AuthTokensResponseSerializer(data=tokens)
+        response_serializer.is_valid(raise_exception=True)
+
+        return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/backend/users/backend/developer/models.py
+++ b/backend/users/backend/developer/models.py
@@ -38,8 +38,8 @@ class DeveloperGroup(BaseGroup):
         DeveloperPermission,
         verbose_name=_("permission"),
         blank=True,
-        related_name='developergroup_set',
-        related_query_name='developergroup',
+        related_name="developergroup_set",
+        related_query_name="developergroup",
     )
 
     class Meta(BaseGroup.Meta):
@@ -72,49 +72,56 @@ class CompanyUserManager(UserManager):
 
 class CompanyUser(BaseAbstractUser, DeveloperPermissionMixin):
     country = models.ForeignKey(
-        Country, on_delete=models.SET_NULL, null=True, verbose_name=_('Developer country')
+        Country,
+        on_delete=models.SET_NULL,
+        null=True,
+        verbose_name=_("Developer country"),
     )
-    avatar = models.ImageField(blank=True, verbose_name=_('Developer avatar'))
+    avatar = models.ImageField(blank=True, verbose_name=_("Developer avatar"))
     is_active = models.BooleanField(default=False)
     is_superuser = models.BooleanField(default=False)
     groups = models.ManyToManyField(
-        'DeveloperGroup',
+        "DeveloperGroup",
         verbose_name=_("developer_groups"),
         blank=True,
         help_text=_(
             "The groups this user belongs to. A user will get all permissions "
             "granted to each of their groups."
         ),
-        related_name='companyuser_set',
-        related_query_name='companyuser',
+        related_name="companyuser_set",
+        related_query_name="companyuser",
     )
 
     user_permissions = models.ManyToManyField(
-        'DeveloperPermission',
-        verbose_name=_('developer permissions'),
+        "DeveloperPermission",
+        verbose_name=_("developer permissions"),
         blank=True,
-        help_text=_('Specific permissions for this developer.'),
-        related_name='companyuser_set',
-        related_query_name='companyuser',
+        help_text=_("Specific permissions for this developer."),
+        related_name="companyuser_set",
+        related_query_name="companyuser",
     )
     company = models.ForeignKey(
-        'Company',
+        "Company",
         on_delete=models.CASCADE,
-        verbose_name=_('Company'),
-        related_name='companyuser_set',
+        verbose_name=_("Company"),
+        related_name="companyuser_set",
         blank=True,
         null=True,
     )
 
     objects = CompanyUserManager()
 
+    @property
+    def permissions_codename(self) -> list[str]:
+        return list(self.user_permissions.values_list("codename", flat=True))
+
     def __str__(self):
         return self.username
 
     class Meta:
         db_table = "company_user"
-        verbose_name = _('company user')
-        verbose_name_plural = _('company users')
+        verbose_name = _("company user")
+        verbose_name_plural = _("company users")
 
 
 class Company(models.Model):
@@ -122,32 +129,32 @@ class Company(models.Model):
     created_by = models.OneToOneField(
         CompanyUser,
         on_delete=models.PROTECT,
-        verbose_name=_('Company owner'),
-        related_name='company_owner',
+        verbose_name=_("Company owner"),
+        related_name="company_owner",
     )
     contact = models.ManyToManyField(
         ContactType,
-        through='CompanyContact',
-        verbose_name=_('Company contact'),
+        through="CompanyContact",
+        verbose_name=_("Company contact"),
         blank=True,
-        related_name='contact_set',
-        related_query_name='contact',
+        related_name="contact_set",
+        related_query_name="contact",
     )
-    title = models.CharField(max_length=50, verbose_name=_('Company title'))
-    description = models.TextField(verbose_name=_('Company description'))
-    email = models.EmailField(unique=True, verbose_name=_('Company email link'))
-    image = models.ImageField(blank=True, verbose_name=_('Company poster'))
+    title = models.CharField(max_length=50, verbose_name=_("Company title"))
+    description = models.TextField(verbose_name=_("Company description"))
+    email = models.EmailField(unique=True, verbose_name=_("Company email link"))
+    image = models.ImageField(blank=True, verbose_name=_("Company poster"))
     is_confirmed = models.BooleanField(default=False)
-    created_at = models.DateTimeField(auto_now_add=True, verbose_name=_('Company created date'))
+    created_at = models.DateTimeField(auto_now_add=True, verbose_name=_("Company created date"))
     is_active = models.BooleanField(default=True)
 
     def __str__(self):
         return self.title
 
     class Meta:
-        db_table = 'company'
-        verbose_name = _('company')
-        verbose_name_plural = _('companies')
+        db_table = "company"
+        verbose_name = _("company")
+        verbose_name_plural = _("companies")
 
 
 class CompanyContact(models.Model):
@@ -159,12 +166,12 @@ class CompanyContact(models.Model):
     company = models.ForeignKey(
         Company, verbose_name=_("company contacts"), on_delete=models.CASCADE
     )
-    value = models.CharField(max_length=150, verbose_name=_('value contact'), default='')
+    value = models.CharField(max_length=150, verbose_name=_("value contact"), default="")
 
     def __str__(self):
-        return f'{self.type__name}-{self.value}'
+        return f"{self.type__name}-{self.value}"
 
     class Meta:
-        db_table = 'company_contact'
-        verbose_name = _('company contact')
-        verbose_name_plural = _('company contacts')
+        db_table = "company_contact"
+        verbose_name = _("company contact")
+        verbose_name_plural = _("company contacts")

--- a/backend/users/backend/developer/serializers/v1/auth_serializer.py
+++ b/backend/users/backend/developer/serializers/v1/auth_serializer.py
@@ -1,0 +1,8 @@
+from base.serializers import BaseAuthSerializer
+from developer.models import CompanyUser
+
+
+class DeveloperAuthSerializer(BaseAuthSerializer):
+    class Meta:
+        model = CompanyUser
+        fields = ("email", "password")

--- a/backend/users/backend/developer/urls.py
+++ b/backend/users/backend/developer/urls.py
@@ -1,5 +1,6 @@
+from developer.views.v1.auth_view import DeveloperAuthView
 from developer.views.v1 import account_views
-from django.urls import path, include
+from django.urls import path
 from rest_framework import routers
 from developer.views.v1.views import (
     CompanyUserViewSet,
@@ -8,39 +9,47 @@ from developer.views.v1.views import (
 from developer.views.v1.developer_registration_view import DeveloperRegistrationView
 from developer.views.v1 import DeveloperGroupViewSet
 from developer.views.v1 import DeveloperPermissionViewSet
-from developer.views.v1.employee_crud import DeveloperEmployeeListView, DeveloperEmployeeDetailView
+from developer.views.v1.employee_crud import (
+    DeveloperEmployeeListView,
+    DeveloperEmployeeDetailView,
+)
 
 
 router = routers.DefaultRouter()
-router.register(r'developer/users', CompanyUserViewSet, basename='company_users')
-router.register(r'developer/companies', CompanyViewSet, basename='company')
-router.register(r'group', DeveloperGroupViewSet, basename='developer_group')
-router.register(r'permission', DeveloperPermissionViewSet, basename='developer_permission')
+router.register(r"developer/users", CompanyUserViewSet, basename="company_users")
+router.register(r"developer/companies", CompanyViewSet, basename="company")
+router.register(r"group", DeveloperGroupViewSet, basename="developer_group")
+router.register(r"permission", DeveloperPermissionViewSet, basename="developer_permission")
 
 urlpatterns = router.urls
 
 account_router = [
     path(
-        'developer/me',
+        "developer/me",
         account_views.AccountViewSet.as_view(
-            {'get': 'retrieve', 'put': 'partial_update', 'delete': 'destroy'}
+            {"get": "retrieve", "put": "partial_update", "delete": "destroy"}
         ),
-        name='developer-user-account',
+        name="developer-user-account",
     ),
     path(
-        'developer/me/change-password',
-        account_views.ChangePasswordViewSet.as_view({'post': 'create'}),
-        name='developer-user-change-password',
+        "developer/me/change-password",
+        account_views.ChangePasswordViewSet.as_view({"post": "create"}),
+        name="developer-user-change-password",
     ),
 ]
 
 generic_routes = [
-    path('registration/', DeveloperRegistrationView.as_view()),
-    path('employee/', DeveloperEmployeeListView.as_view(), name='developer_users_list'),
+    path("registration/", DeveloperRegistrationView.as_view()),
+    path("employee/", DeveloperEmployeeListView.as_view(), name="developer_users_list"),
     path(
-        'employee/<uuid:pk>/', DeveloperEmployeeDetailView.as_view(), name='developer_users_detail'
+        "employee/<uuid:pk>/",
+        DeveloperEmployeeDetailView.as_view(),
+        name="developer_users_detail",
     ),
 ]
 
+auth_routes = [path("login/", DeveloperAuthView.as_view(), name="developer_login")]
+
 urlpatterns += account_router
 urlpatterns += generic_routes
+urlpatterns += auth_routes

--- a/backend/users/backend/developer/views/v1/auth_view.py
+++ b/backend/users/backend/developer/views/v1/auth_view.py
@@ -3,6 +3,7 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView, Response
+from base.serializers import AuthTokensResponseSerializer
 from developer.serializers.v1.auth_serializer import DeveloperAuthSerializer
 
 from common.services.jwt.token import Token
@@ -12,24 +13,9 @@ class DeveloperAuthView(APIView):
     permission_classes = [AllowAny]
 
     @swagger_auto_schema(
-        request_body=openapi.Schema(
-            type=openapi.TYPE_OBJECT,
-            properties={
-                "email": openapi.Schema(type=openapi.TYPE_STRING),
-                "password": openapi.Schema(type=openapi.TYPE_STRING),
-            },
-            required=["email", "password"],
-        ),
+        request_body=DeveloperAuthSerializer,
         responses={
-            200: openapi.Response(
-                description="Successful authentication",
-                schema=openapi.Schema(
-                    type=openapi.TYPE_OBJECT,
-                    properties={
-                        "tokens": openapi.Schema(type=openapi.TYPE_STRING),
-                    },
-                ),
-            ),
+            200: AuthTokensResponseSerializer,
             400: openapi.Response(description="Email or Password not valid"),
         },
     )
@@ -47,4 +33,7 @@ class DeveloperAuthView(APIView):
 
         tokens = Token().generate_tokens(data=data)
 
-        return Response(tokens, status=status.HTTP_200_OK)
+        response_serializer = AuthTokensResponseSerializer(data=tokens)
+        response_serializer.is_valid(raise_exception=True)
+
+        return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/backend/users/backend/developer/views/v1/auth_view.py
+++ b/backend/users/backend/developer/views/v1/auth_view.py
@@ -1,0 +1,26 @@
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.views import APIView, Response
+from developer.serializers.v1.auth_serializer import DeveloperAuthSerializer
+
+from common.services.jwt.token import Token
+
+
+class DeveloperAuthView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        serializer = DeveloperAuthSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        developer = serializer.validated_data["user"]
+        data = {
+            "user_id": str(developer.id),
+            "role": developer._meta.app_label,
+            "avatar": str(developer.avatar),
+            "permissions": developer.permissions_codename,
+        }
+
+        tokens = Token().generate_tokens(data=data)
+
+        return Response(tokens, status=status.HTTP_200_OK)

--- a/backend/users/backend/developer/views/v1/auth_view.py
+++ b/backend/users/backend/developer/views/v1/auth_view.py
@@ -1,3 +1,5 @@
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView, Response
@@ -9,6 +11,28 @@ from common.services.jwt.token import Token
 class DeveloperAuthView(APIView):
     permission_classes = [AllowAny]
 
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "email": openapi.Schema(type=openapi.TYPE_STRING),
+                "password": openapi.Schema(type=openapi.TYPE_STRING),
+            },
+            required=["email", "password"],
+        ),
+        responses={
+            200: openapi.Response(
+                description="Successful authentication",
+                schema=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        "tokens": openapi.Schema(type=openapi.TYPE_STRING),
+                    },
+                ),
+            ),
+            400: openapi.Response(description="Email or Password not valid"),
+        },
+    )
     def post(self, request):
         serializer = DeveloperAuthSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/backend/users/backend/developer/views/v1/auth_view.py
+++ b/backend/users/backend/developer/views/v1/auth_view.py
@@ -18,6 +18,7 @@ class DeveloperAuthView(APIView):
             200: AuthTokensResponseSerializer,
             400: openapi.Response(description="Email or Password not valid"),
         },
+        tags=["Аутентификация Developer"],
     )
     def post(self, request):
         serializer = DeveloperAuthSerializer(data=request.data)


### PR DESCRIPTION
Привет!

Я хотел бы предложить следующие изменения в коде:

1. В файле `base/serializers.py` я добавил базовый сериализатор `BaseAuthSerializer`, который будет использоваться для всех моделей пользователей (`Admin`, `CompanyUser`, `CustomerUser`).
2. Добавил свойство `permissions_codename` для получения списка прав из поля `user_permissions` и `developer_permissions` для модели `Admin` и `user_permissions` для модели `Developer`.
3. В файлах `views/v1/auth_view.py` я добавил представления `AdminAuthView`, `CompanyAuthView` и `CustomerAuthView` для обработки запросов, связанных с соответствующими моделями пользователей. В каждом представлении используется свой сериалайзер который наследуется от `BaseAuthSerializer` для сериализации пользователей.
4. В файле `base/base_tests/test_base_auth_serializer.py` я добавил тесты для проверки функциональности `BaseAuthSerializer`.
5. В модели `CustomerUser` я добавил свойство `age`, которое рассчитывается на основе поля `birthday`. Теперь можно получить возраст клиента через это свойство.
6. В файлах `urls.py` я добавил URL-маршруты для каждой сущности (`Admin`, `CompanyUser`, `CustomerUser`), чтобы связать их с соответствующими представлениями.
7. Добавил описание ручек для `AdminAuthView`, `DeveloperAuthView`, `CustomerAuthView` к документации Swagger.

Пост Скриптум: Исправление ошибки в классе `CustomerAuthView`

В ходе разработки класса `CustomerAuthView` была допущена ошибка, связанная с отсутствием поля `user_permissions` у модели `CustomerUser`. Было обнаружено, что код метода `permissions_codename` не учитывает это и вызывает ошибку при его выполнении.

Я среагировал на эту проблему и внес необходимые исправления в моём последнем коммите. Теперь код класса `CustomerAuthView` работает корректно.