### PR TITLE
Overriding the create method of the UserAccountAPIView class

### DIFF
--- a/backend/payments/apps/payment_accounts/views.py
+++ b/backend/payments/apps/payment_accounts/views.py
@@ -58,6 +58,16 @@ class BalanceIncreaseView(CreateAPIView, DRFtoDataClassMixin):
 class UserAccountAPIView(CreateAPIView, DRFtoDataClassMixin):
     serializer_class = serializers.AccountSerializer
 
+    def create(self, request, *args, **kwargs):
+        uuid = request.data.get('user_uuid')
+        if Account.objects.filter(user_uuid=uuid).exists():
+            return Response(
+                {'error': 'A user with this UUID already exists'},
+                status=status.HTTP_409_CONFLICT,
+            )
+        else:
+            return super().create(request, *args, **kwargs)
+
 
 class PayoutView(viewsets.ViewSet, DRFtoDataClassMixin):
     serializer_class = serializers.PayoutSerializer


### PR DESCRIPTION
The create method has been redefined in the User Account API View class. Added checking for the presence of UUID in the database. If there is a UUID in the database, a response with error 409 is returned instead of 500.