### PR TITLE
Payments | Correction of an error when creating an account whose UUID is already in the database

### DIFF
--- a/backend/payments/apps/payment_accounts/views.py
+++ b/backend/payments/apps/payment_accounts/views.py
@@ -58,6 +58,16 @@ class BalanceIncreaseView(CreateAPIView, DRFtoDataClassMixin):
 class UserAccountAPIView(CreateAPIView, DRFtoDataClassMixin):
     serializer_class = serializers.AccountSerializer
 
+    def create(self, request, *args, **kwargs):
+        uuid = request.data.get('user_uuid')
+        if Account.objects.filter(user_uuid=uuid).exists():
+            return Response(
+                {'error': 'A user with this UUID already exists'},
+                status=status.HTTP_409_CONFLICT,
+            )
+        else:
+            return super().create(request, *args, **kwargs)
+
 
 class PayoutView(viewsets.ViewSet, DRFtoDataClassMixin):
     serializer_class = serializers.PayoutSerializer

--- a/backend/payments/apps/payment_accounts/views.py
+++ b/backend/payments/apps/payment_accounts/views.py
@@ -65,8 +65,7 @@ class UserAccountAPIView(CreateAPIView, DRFtoDataClassMixin):
                 {'error': 'A user with this UUID already exists'},
                 status=status.HTTP_409_CONFLICT,
             )
-        else:
-            return super().create(request, *args, **kwargs)
+        return super().create(request, *args, **kwargs)
 
 
 class PayoutView(viewsets.ViewSet, DRFtoDataClassMixin):


### PR DESCRIPTION
The create method in the UserAccountAPIView class has been redefined. Changed the error returned when creating an account that already exists in the database