### PR TITLE
Users | post/put/delete company functional for developer

### DIFF
--- a/backend/users/backend/common/permissions/verifiers.py
+++ b/backend/users/backend/common/permissions/verifiers.py
@@ -46,7 +46,7 @@ class CustomerScopeUserVerify(AbstractUserVerify):
 class CompanyOwnerVerify(AbstractUserVerify):
     def verify(self, user) -> bool:
         if isinstance(user, CompanyUser):
-            return Company.objects.filter(created_by=user).exists()
+            return user.is_superuser or Company.objects.filter(created_by=user).exists()
         return False
 
 

--- a/backend/users/backend/developer/permissions.py
+++ b/backend/users/backend/developer/permissions.py
@@ -1,17 +1,5 @@
-from rest_framework.permissions import BasePermission
-
 from common.permissions.permissons import CompanyOwnerPerm
 from developer.models import CompanyUser, Company
-
-
-class IsAdminOrOwnerCompany(BasePermission):
-    def has_object_permission(self, request, view, obj):
-        return obj.created_by == request.user or request.user.is_staff
-
-
-class IsAdmin(BasePermission):
-    def has_permission(self, request, view):
-        return request.user.is_staff
 
 
 class CompanyOwnerEmployeePerm(CompanyOwnerPerm):

--- a/backend/users/backend/developer/serializers/serializers.py
+++ b/backend/users/backend/developer/serializers/serializers.py
@@ -5,16 +5,16 @@ from developer.models import CompanyUser, Company
 class CompanyUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = CompanyUser
-        fields = '__all__'
+        fields = "__all__"
 
 
 class CompanySerializer(serializers.ModelSerializer):
     class Meta:
         model = Company
-        fields = '__all__'
+        fields = ("title", "description", "contact", "email", "created_by", "image")
 
 
 class CompanyEmployeeSerializer(CompanySerializer):
     class Meta:
         model = Company
-        fields = ('email', 'description', 'image', 'created_by')
+        fields = ("email", "description", "image", "created_by")

--- a/backend/users/backend/developer/serializers/v1/company_serializer.py
+++ b/backend/users/backend/developer/serializers/v1/company_serializer.py
@@ -1,10 +1,14 @@
 from rest_framework import serializers
-from developer.models import CompanyUser, Company
+from developer.models import Company
 from rest_framework.exceptions import ValidationError
 
 
 class CompanyCreateSerializer(serializers.ModelSerializer):
     created_by = serializers.HiddenField(default=serializers.CurrentUserDefault())
+
+    class Meta:
+        model = Company
+        fields = ("title", "description", "contact", "email", "created_by", "image")
 
     def validate(self, attrs):
         user = self.context["request"].user
@@ -12,13 +16,15 @@ class CompanyCreateSerializer(serializers.ModelSerializer):
             raise ValidationError("User can create only one company")
         return attrs
 
+
+class CompanyUpdateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Company
-        fields = ("title", "description", "contact", "email", "created_by", "image")
+        fields = ("title", "description", "contact", "email", "image")
+        read_only_fields = ("created_by",)
 
 
 class CompanySerializer(serializers.ModelSerializer):
     class Meta:
         model = Company
         fields = ("title", "description", "contact", "email", "created_by", "image")
-        read_only_fields = ("created_by",)

--- a/backend/users/backend/developer/serializers/v1/company_serializer.py
+++ b/backend/users/backend/developer/serializers/v1/company_serializer.py
@@ -1,0 +1,24 @@
+from rest_framework import serializers
+from developer.models import CompanyUser, Company
+from rest_framework.exceptions import ValidationError
+
+
+class CompanyCreateSerializer(serializers.ModelSerializer):
+    created_by = serializers.HiddenField(default=serializers.CurrentUserDefault())
+
+    def validate(self, attrs):
+        user = self.context["request"].user
+        if Company.objects.filter(created_by=user).exists():
+            raise ValidationError("User can create only one company")
+        return attrs
+
+    class Meta:
+        model = Company
+        fields = ("title", "description", "contact", "email", "created_by", "image")
+
+
+class CompanySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Company
+        fields = ("title", "description", "contact", "email", "created_by", "image")
+        read_only_fields = ("created_by",)

--- a/backend/users/backend/developer/serializers/v1/developer_registration_serializer.py
+++ b/backend/users/backend/developer/serializers/v1/developer_registration_serializer.py
@@ -6,7 +6,7 @@ from developer.models import CompanyUser
 class DeveloperRegistrationSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         """send totp"""
-        return CompanyUser.objects.create_user(**validated_data, is_superuser=False)
+        return CompanyUser.objects.create_superuser(**validated_data, is_superuser=True)
 
     class Meta:
         model = CompanyUser

--- a/backend/users/backend/developer/tests/test_company_view.py
+++ b/backend/users/backend/developer/tests/test_company_view.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import List, Optional, Union
 
 from django.test import TestCase
 from django.urls import reverse
@@ -50,8 +51,68 @@ class CompanyTestAPI(BaseTestView, TestCase):
         )
 
     ##################################
-    ###    Testing post method     ###
+    ####    Testing get method    ####
     ##################################
+    def test_get_company_by_user_who_have_his_own_company(self):
+        superuser_developer = CompanyUser.objects.create_user(
+            username="test super_user1",
+            email="testuse1r@example.com",
+            phone="12314567890",
+            password="testpassword1",
+            is_active=True,
+            is_superuser=True,
+        )
+        Company.objects.create(
+            created_by=superuser_developer,
+            title="company",
+            description="company_description",
+            email="company@email.com",
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(superuser_developer))
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_company_by_user_who_dont_have_any_own_company(self):
+        superuser_developer = CompanyUser.objects.create_user(
+            username="test super_user1",
+            email="testuse1r@example.com",
+            phone="12314567890",
+            password="testpassword1",
+            is_active=True,
+            is_superuser=True,
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(superuser_developer))
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_users_permission_deny(self):
+        employer = CompanyUser.objects.create_user(
+            username="test super_user1",
+            email="testuse1r@example.com",
+            phone="12314567890",
+            password="testpassword1",
+            is_active=True,
+            is_superuser=False,
+        )
+        Company.objects.create(
+            created_by=employer,
+            title="company",
+            description="company_description",
+            email="company@email.com",
+        )
+        incorrect_users_list: List[Union[CustomerUser, Admin, CustomerUser]] = [
+            self.admin_user,
+            self.customer_user,
+            self.developer,
+        ]
+        for user in incorrect_users_list:
+            self.client.credentials(HTTP_AUTHORIZATION=self.get_token(user))
+            response = self.client.get(self.url)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # ##################################
+    # ###    Testing post method     ###
+    # ##################################
 
     def test_superuser_developer_can_create_company(self):
         data = {
@@ -97,7 +158,7 @@ class CompanyTestAPI(BaseTestView, TestCase):
         }
         self.client.credentials(HTTP_AUTHORIZATION=self.get_token(self.admin_user))
         response = self.client.post(self.url, data)
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(Company.objects.count(), 0)
 
     def test_customer_user_cant_create_company(self):
@@ -122,7 +183,7 @@ class CompanyTestAPI(BaseTestView, TestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(Company.objects.count(), 0)
 
-    def test_developer_cant_create_multiply_companies(self):
+    def test_superuser_developer_cant_create_multiply_companies(self):
         company_owner = CompanyUser.objects.create_user(
             username="testuser1",
             email="testuser1@example.com",
@@ -152,122 +213,36 @@ class CompanyTestAPI(BaseTestView, TestCase):
 
     def test_developer_can_update_own_company(self):
         company_owner = self.superuser_developer
-        company = Company.objects.create(
+        Company.objects.create(
             created_by=company_owner,
             title="company1",
             description="company_description",
             email="company@email.com",
         )
-        url = reverse("company_detail", args=[company.id])
+
         new_data = {
             "title": "My Company",
         }
         self.client.credentials(HTTP_AUTHORIZATION=self.get_token(company_owner))
-        response = self.client.put(url, new_data)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-    def test_developer_cant_update_created_by_field_on_own_company(self):
-        company_owner = self.superuser_developer
-        company = Company.objects.create(
-            created_by=company_owner,
-            title="company1",
-            description="company_description",
-            email="company@email.com",
-        )
-
-        url = reverse("company_detail", args=[company.id])
-        new_data = {
-            "created_by": self.developer,
-        }
-        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(company_owner))
-        response = self.client.put(url, new_data)
-        self.assertEqual(
-            company,
-            Company.objects.get(
-                created_by=CompanyUser.objects.get(id=response.data["created_by"])
-            ),
-        )
+        response = self.client.put(self.url, new_data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_developer_can_update_own_company_but_invalid_data(self):
-        company_owner = self.developer
-        company = Company.objects.create(
+        company_owner = self.superuser_developer
+        Company.objects.create(
             created_by=company_owner,
             title="company1",
             description="company_description",
             email="company@email.com",
         )
-        url = reverse("company_detail", args=[company.id])
+
         new_data = {
             "title": str("a" * 51),
         }
         self.client.credentials(HTTP_AUTHORIZATION=self.get_token(company_owner))
-        response = self.client.put(url, new_data)
+        response = self.client.put(self.url, new_data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_developer_cant_update_not_own_company(self):
-        company_owner = CompanyUser.objects.create_user(
-            username="testuser2",
-            email="testuser2@example.com",
-            phone="12345267890",
-            password="testpassword2",
-            is_active=True,
-        )
-
-        company = Company.objects.create(
-            created_by=self.developer,
-            title="company1",
-            description="company_description",
-            email="company@email.com",
-        )
-
-        url = reverse("company_detail", args=[company.id])
-
-        new_data = {
-            "title": "My Company",
-        }
-
-        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(company_owner))
-        response = self.client.put(url, new_data)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_customer_user_cant_update_company(self):
-        company = Company.objects.create(
-            created_by=self.developer,
-            title="company1",
-            description="company_description",
-            email="company@email.com",
-        )
-
-        url = reverse("company_detail", args=[company.id])
-
-        new_data = {
-            "title": "My Company",
-        }
-
-        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(self.customer_user))
-        response = self.client.put(url, new_data)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_unauthorized_user_cant_update_company(self):
-        company = Company.objects.create(
-            created_by=self.developer,
-            title="company1",
-            description="company_description",
-            email="company@email.com",
-        )
-
-        url = reverse("company_detail", args=[company.id])
-
-        new_data = {
-            "title": "My Company",
-        }
-
-        self.client.credentials(HTTP_AUTHORIZATION="")
-        response = self.client.put(url, new_data)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     ##################################
     ###   Testing delete method    ###
@@ -275,59 +250,37 @@ class CompanyTestAPI(BaseTestView, TestCase):
 
     def test_developer_can_delete_own_company(self):
         company_owner = self.superuser_developer
-        company = Company.objects.create(
+        Company.objects.create(
             created_by=company_owner,
             title="company1",
             description="company_description",
             email="company@email.com",
         )
-        url = reverse("company_detail", args=[company.id])
 
         self.client.credentials(HTTP_AUTHORIZATION=self.get_token(company_owner))
-        response = self.client.delete(url)
+        response = self.client.delete(self.url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-    def test_developer_cant_delete_not_own_company(self):
-        not_company_owner = CompanyUser.objects.create_user(
-            "company_owner2",
-            "company_owner2@mail.ru",
-            "980348988",
-            "company_owner2",
-        )
-        company = Company.objects.create(
-            created_by=self.superuser_developer,
-            title="company1",
-            description="company_description",
-            email="company@email.com",
-        )
-        url = reverse("company_detail", args=[company.id])
-
-        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(not_company_owner))
-        response = self.client.delete(url)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
     def test_admin_cant_delete_company(self):
-        company = Company.objects.create(
+        Company.objects.create(
             created_by=self.developer,
             title="company1",
             description="company_description",
             email="company@email.com",
         )
-        url = reverse("company_detail", args=[company.id])
 
         self.client.credentials(HTTP_AUTHORIZATION=self.get_token(self.admin_user))
-        response = self.client.delete(url)
+        response = self.client.delete(self.url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_customer_cant_delete_company(self):
-        company = Company.objects.create(
+        Company.objects.create(
             created_by=self.developer,
             title="company1",
             description="company_description",
             email="company@email.com",
         )
-        url = reverse("company_detail", args=[company.id])
 
         self.client.credentials(HTTP_AUTHORIZATION=self.get_token(self.customer_user))
-        response = self.client.delete(url)
+        response = self.client.delete(self.url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/backend/users/backend/developer/tests/test_company_view.py
+++ b/backend/users/backend/developer/tests/test_company_view.py
@@ -1,0 +1,266 @@
+import datetime
+
+from django.test import TestCase
+from django.urls import reverse
+
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from administrator.models import Admin
+from base.base_tests.tests import BaseTestView
+from common.services.jwt.token import Token
+from customer.models import CustomerUser
+from developer.models import Company, CompanyUser
+
+
+class CompanyTestAPI(BaseTestView, TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("companies")
+        cls.admin_user = Admin.objects.create_superuser(
+            username="adminR",
+            email="adminR@test.com",
+            phone="891123123",
+            password="testpass123R",
+            is_active=True,
+        )
+        cls.customer_user = CustomerUser.objects.create_user(
+            username="test_user",
+            email="email@mail.ru",
+            password="test_user1",
+            first_name="user_test_name",
+            last_name="user_test_name",
+            phone="89991234567",
+            birthday=datetime.date.today(),
+            is_active=True,
+        )
+        cls.developer = CompanyUser.objects.create_user(
+            username="testuser",
+            email="testuser@example.com",
+            phone="1234567890",
+            password="testpassword",
+            is_active=True,
+        )
+
+    def test_developer_can_create_company(self):
+        data = {
+            "title": "My Company",
+            "description": "We are a company that does things.",
+            "email": "info@mycompany.com",
+        }
+        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(self.developer))
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Company.objects.count(), 1)
+
+    # def test_admin_can_create_company(self):
+    #     data = {
+    #         "title": "My Company",
+    #         "description": "We are a company that does things.",
+    #         "email": "info@mycompany.com",
+    #     }
+    #     self.client.credentials(HTTP_AUTHORIZATION=self.get_token(self.admin_user))
+    #     response = self.client.post(self.url, data)
+    #     self.assertEqual(response.status_code, 400)
+    #     self.assertEqual(Company.objects.count(), 0)
+
+    def test_customer_user_cant_create_company(self):
+        data = {
+            "title": "My Company",
+            "description": "We are a company that does things.",
+            "email": "info@mycompany.com",
+        }
+        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(self.customer_user))
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(Company.objects.count(), 0)
+
+    def test_unautorized_user_can_create_company(self):
+        data = {
+            "title": "My Company",
+            "description": "We are a company that does things.",
+            "email": "info@mycompany.com",
+        }
+        self.client.credentials(HTTP_AUTHORIZATION="")
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(Company.objects.count(), 0)
+
+    def test_developer_cant_create_multiply_companies(self):
+        company_owner = CompanyUser.objects.create_user(
+            username="testuser1",
+            email="testuser1@example.com",
+            phone="12345617890",
+            password="testpassword1",
+            is_active=True,
+        )
+        Company.objects.create(
+            created_by=company_owner,
+            title="company",
+            description="company_description",
+            email="company@email.com",
+        )
+        data = {
+            "title": "My Company",
+            "description": "We are a company that does things.",
+            "email": "info@mycompany.com",
+        }
+        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(company_owner))
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_developer_can_update_own_company(self):
+        company_owner = self.developer
+        company = Company.objects.create(
+            created_by=company_owner,
+            title="company1",
+            description="company_description",
+            email="company@email.com",
+        )
+        url = reverse("company_detail", args=[company.title])
+        new_data = {
+            "title": "My Company",
+        }
+        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(company_owner))
+        response = self.client.put(url, new_data)
+        self.assertEqual(response.data["title"], new_data["title"])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_developer_can_update_own_company_but_invalid_data(self):
+        company_owner = self.developer
+        company = Company.objects.create(
+            created_by=company_owner,
+            title="company1",
+            description="company_description",
+            email="company@email.com",
+        )
+        url = reverse("company_detail", args=[company.title])
+        new_data = {
+            "title": str("a" * 51),
+        }
+        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(company_owner))
+        response = self.client.put(url, new_data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_developer_cant_update_not_own_company(self):
+        company_owner = CompanyUser.objects.create_user(
+            username="testuser2",
+            email="testuser2@example.com",
+            phone="12345267890",
+            password="testpassword2",
+            is_active=True,
+        )
+
+        company = Company.objects.create(
+            created_by=self.developer,
+            title="company1",
+            description="company_description",
+            email="company@email.com",
+        )
+
+        url = reverse("company_detail", args=[company.title])
+
+        new_data = {
+            "title": "My Company",
+        }
+
+        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(company_owner))
+        response = self.client.put(url, new_data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_customer_user_cant_update_company(self):
+        company = Company.objects.create(
+            created_by=self.developer,
+            title="company1",
+            description="company_description",
+            email="company@email.com",
+        )
+
+        url = reverse("company_detail", args=[company.title])
+
+        new_data = {
+            "title": "My Company",
+        }
+
+        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(self.customer_user))
+        response = self.client.put(url, new_data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unauthorized_user_cant_update_company(self):
+        company = Company.objects.create(
+            created_by=self.developer,
+            title="company1",
+            description="company_description",
+            email="company@email.com",
+        )
+
+        url = reverse("company_detail", args=[company.title])
+
+        new_data = {
+            "title": "My Company",
+        }
+
+        self.client.credentials(HTTP_AUTHORIZATION="")
+        response = self.client.put(url, new_data)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_developer_can_delete_own_company(self):
+        company_owner = self.developer
+        company = Company.objects.create(
+            created_by=company_owner,
+            title="company1",
+            description="company_description",
+            email="company@email.com",
+        )
+        url = reverse("company_detail", args=[company.title])
+
+        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(company_owner))
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_developer_cant_delete_not_own_company(self):
+        company_owner = CompanyUser.objects.create_user(
+            "company_owner2",
+            "company_owner2@mail.ru",
+            "980348988",
+            "company_owner2",
+        )
+        company = Company.objects.create(
+            created_by=self.developer,
+            title="company1",
+            description="company_description",
+            email="company@email.com",
+        )
+        url = reverse("company_detail", args=[company.title])
+
+        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(company_owner))
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    # def test_admin_cant_delete_company(self):
+    #     company = Company.objects.create(
+    #         created_by=self.developer,
+    #         title="company1",
+    #         description="company_description",
+    #         email="company@email.com",
+    #     )
+    #     url = reverse("company_detail", args=[company.title])
+
+    #     self.client.credentials(HTTP_AUTHORIZATION=self.get_token(self.admin_user))
+    #     response = self.client.delete(url)
+    #     self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_customer_cant_delete_company(self):
+        company = Company.objects.create(
+            created_by=self.developer,
+            title="company1",
+            description="company_description",
+            email="company@email.com",
+        )
+        url = reverse("company_detail", args=[company.title])
+
+        self.client.credentials(HTTP_AUTHORIZATION=self.get_token(self.customer_user))
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/backend/users/backend/developer/tests/test_company_view.py
+++ b/backend/users/backend/developer/tests/test_company_view.py
@@ -40,6 +40,7 @@ class CompanyTestAPI(BaseTestView, TestCase):
             phone="1234567890",
             password="testpassword",
             is_active=True,
+            is_superuser=True,
         )
 
     def test_developer_can_create_company(self):
@@ -237,7 +238,7 @@ class CompanyTestAPI(BaseTestView, TestCase):
 
         self.client.credentials(HTTP_AUTHORIZATION=self.get_token(company_owner))
         response = self.client.delete(url)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     # def test_admin_cant_delete_company(self):
     #     company = Company.objects.create(
@@ -263,4 +264,4 @@ class CompanyTestAPI(BaseTestView, TestCase):
 
         self.client.credentials(HTTP_AUTHORIZATION=self.get_token(self.customer_user))
         response = self.client.delete(url)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/backend/users/backend/developer/urls.py
+++ b/backend/users/backend/developer/urls.py
@@ -9,7 +9,7 @@ from developer.views.v1.employee_crud import (
     DeveloperEmployeeListView,
     DeveloperEmployeeDetailView,
 )
-from developer.views.v1.company_view import CompanyAPIView
+from developer.views.v1.company_view import CompanyListAPIView, CompanyDetailAPIView
 
 router = routers.DefaultRouter()
 router.register(r"group", DeveloperGroupViewSet, basename="developer_group")
@@ -46,8 +46,8 @@ generic_routes = [
 auth_routes = [path("login/", DeveloperAuthView.as_view(), name="developer_login")]
 
 company_urls = [
-    path("companies/", CompanyAPIView.as_view(), name="companies"),
-    path("companies/<str:title>/", CompanyAPIView.as_view(), name="company_detail"),
+    path("company/", CompanyListAPIView.as_view(), name="company"),
+    path("company/<uuid:pk>/", CompanyDetailAPIView.as_view(), name="company_detail"),
 ]
 
 urlpatterns += account_router

--- a/backend/users/backend/developer/urls.py
+++ b/backend/users/backend/developer/urls.py
@@ -9,11 +9,13 @@ from developer.views.v1.employee_crud import (
     DeveloperEmployeeListView,
     DeveloperEmployeeDetailView,
 )
-from developer.views.v1.company_view import CompanyListAPIView, CompanyDetailAPIView
+from developer.views.v1.company_view import CompanyAPIView
 
 router = routers.DefaultRouter()
 router.register(r"group", DeveloperGroupViewSet, basename="developer_group")
-router.register(r"permission", DeveloperPermissionViewSet, basename="developer_permission")
+router.register(
+    r"permission", DeveloperPermissionViewSet, basename="developer_permission"
+)
 
 
 urlpatterns = router.urls
@@ -46,8 +48,7 @@ generic_routes = [
 auth_routes = [path("login/", DeveloperAuthView.as_view(), name="developer_login")]
 
 company_urls = [
-    path("company/", CompanyListAPIView.as_view(), name="company"),
-    path("company/<uuid:pk>/", CompanyDetailAPIView.as_view(), name="company_detail"),
+    path("company/", CompanyAPIView.as_view(), name="company"),
 ]
 
 urlpatterns += account_router

--- a/backend/users/backend/developer/urls.py
+++ b/backend/users/backend/developer/urls.py
@@ -9,11 +9,13 @@ from developer.views.v1.employee_crud import (
     DeveloperEmployeeListView,
     DeveloperEmployeeDetailView,
 )
-
+from developer.views.v1.company_view import CompanyAPIView
 
 router = routers.DefaultRouter()
-router.register(r'group', DeveloperGroupViewSet, basename='developer_group')
-router.register(r'permission', DeveloperPermissionViewSet, basename='developer_permission')
+router.register(r"group", DeveloperGroupViewSet, basename="developer_group")
+router.register(
+    r"permission", DeveloperPermissionViewSet, basename="developer_permission"
+)
 
 
 urlpatterns = router.urls
@@ -45,6 +47,12 @@ generic_routes = [
 
 auth_routes = [path("login/", DeveloperAuthView.as_view(), name="developer_login")]
 
+company_urls = [
+    path("companies/", CompanyAPIView.as_view(), name="companies"),
+    path("companies/<str:title>/", CompanyAPIView.as_view(), name="company_detail"),
+]
+
 urlpatterns += account_router
 urlpatterns += generic_routes
 urlpatterns += auth_routes
+urlpatterns += company_urls

--- a/backend/users/backend/developer/urls.py
+++ b/backend/users/backend/developer/urls.py
@@ -13,9 +13,7 @@ from developer.views.v1.company_view import CompanyAPIView
 
 router = routers.DefaultRouter()
 router.register(r"group", DeveloperGroupViewSet, basename="developer_group")
-router.register(
-    r"permission", DeveloperPermissionViewSet, basename="developer_permission"
-)
+router.register(r"permission", DeveloperPermissionViewSet, basename="developer_permission")
 
 
 urlpatterns = router.urls

--- a/backend/users/backend/developer/views/v1/company_view.py
+++ b/backend/users/backend/developer/views/v1/company_view.py
@@ -1,0 +1,127 @@
+from django.shortcuts import get_object_or_404
+from django.utils.decorators import method_decorator
+
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
+
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import (
+    IsAuthenticatedOrReadOnly,
+    IsAuthenticated,
+    IsAdminUser,
+    AllowAny,
+)
+
+from base.views import PartialUpdateMixin
+from developer.models import Company, CompanyUser
+from developer.permissions import IsAdminOrOwnerCompany
+from developer.serializers.serializers import (
+    CompanySerializer,
+    CompanyEmployeeSerializer,
+)
+
+
+class CompanyAPIView(APIView):
+    http_method_names = ["get", "post", "put", "delete"]
+    queryset = Company.objects.all()
+    serializer_class = CompanySerializer
+    permission_classes = (IsAdminOrOwnerCompany,)
+
+    def get_permissions(self):
+        if self.request.method.lower() == "get":
+            permission_classes = [AllowAny]
+        else:
+            permission_classes = self.permission_classes
+        return [permission() for permission in permission_classes]
+
+    @method_decorator(
+        name="get",
+        decorator=swagger_auto_schema(
+            operation_description="Просмотр списка/отдельной компании",
+            tags=["Разработчик", "Административная панель разработчика"],
+            responses={
+                200: openapi.Response("Компания разработчика", CompanySerializer),
+                404: openapi.Response("Компания не найдена"),
+            },
+        ),
+    )
+    def get(self, request, title=None, format=None):
+        print(request.method.lower())
+        if title:
+            company = Company.objects.get(title=title)
+            serializer = self.serializer_class(company, many=False)
+            return Response(serializer.data)
+
+        companies = Company.objects.all()
+        serializer = self.serializer_class(companies, many=True)
+        return Response(serializer.data)
+
+    @method_decorator(
+        name="post",
+        decorator=swagger_auto_schema(
+            operation_description="Добавить компанию",
+            request_body=CompanySerializer,
+            tags=["Разработчик", "Административная панель разработчика"],
+            responses={
+                201: openapi.Response("Компания", CompanySerializer),
+                400: openapi.Response("Невалидные данные"),
+                403: openapi.Response("Отсутствуют права на создание компании"),
+            },
+        ),
+    )
+    def post(self, request, *args, **kwargs):
+        user = request.user
+        if not isinstance(user, CompanyUser):
+            return Response(
+                {"error": "You are not authorized to edit this company."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        data = request.data.copy()
+        data["created_by"] = user.id
+
+        serializer = self.serializer_class(data=data)
+
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    @method_decorator(
+        name="update",
+        decorator=swagger_auto_schema(
+            operation_description="Изменить данные компании",
+            tags=["Разработчик", "Административная панель разработчика"],
+            responses={
+                200: openapi.Response("Компания", CompanySerializer),
+                400: openapi.Response("Невалидные данные"),
+                403: openapi.Response("Отсутствуют права"),
+                404: openapi.Response("Компания не найдена"),
+            },
+        ),
+    )
+    def put(self, request, title, format=None):
+        company = get_object_or_404(self.queryset, title=title)
+        if company.created_by != request.user:
+            return Response(
+                {"error": "You are not authorized to edit this company."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        serializer = self.serializer_class(company, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        return Response(serializer.data)
+
+    def delete(self, request, title, format=None):
+        company = get_object_or_404(Company, title=title)
+        if company.created_by != request.user:
+            return Response(
+                {"error": "You are not authorized to delete this company."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+        company.delete()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/users/backend/developer/views/v1/company_view.py
+++ b/backend/users/backend/developer/views/v1/company_view.py
@@ -8,18 +8,13 @@ from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import (
-    IsAuthenticatedOrReadOnly,
-    IsAuthenticated,
-    IsAdminUser,
     AllowAny,
 )
 
-from base.views import PartialUpdateMixin
+from common.permissions.permissons import CompanyOwnerPerm
 from developer.models import Company, CompanyUser
-from developer.permissions import IsAdminOrOwnerCompany
 from developer.serializers.serializers import (
     CompanySerializer,
-    CompanyEmployeeSerializer,
 )
 
 
@@ -27,7 +22,7 @@ class CompanyAPIView(APIView):
     http_method_names = ["get", "post", "put", "delete"]
     queryset = Company.objects.all()
     serializer_class = CompanySerializer
-    permission_classes = (IsAdminOrOwnerCompany,)
+    permission_classes = (CompanyOwnerPerm,)
 
     def get_permissions(self):
         if self.request.method.lower() == "get":

--- a/backend/users/backend/developer/views/v1/company_view.py
+++ b/backend/users/backend/developer/views/v1/company_view.py
@@ -50,9 +50,9 @@ delete_method_schema = swagger_auto_schema(
     operation_description="Удалить компанию",
     tags=["Разработчик", "Административная панель разработчика"],
     responses={
-        204: openapi.Response("Пользователь удалён"),
+        204: openapi.Response("Компания удалена"),
         403: openapi.Response("Отсутствуют права на удаление"),
-        404: openapi.Response("Компания не найден"),
+        404: openapi.Response("Компания не создана"),
     },
 )
 
@@ -75,25 +75,20 @@ class CompanyAPIView(APIView):
         )
         serializer.is_valid(raise_exception=True)
         serializer.save()
-
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     @put_method_schema
     def put(self, request, format=None):
         user = request.user
         company = get_object_or_404(Company, created_by=user)
-
         serializer = CompanyUpdateSerializer(company, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
-
         return Response(serializer.data)
 
     @delete_method_schema
     def delete(self, request, format=None):
         user = request.user
-
         company = get_object_or_404(Company, created_by=user)
         company.delete()
-
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Перед мерджем хотел бы обсудить следущие вопросы:

При запросах поле created_by - является обязательным, и в форме запроса оно отображается, но по нашему функционалу заполняется автоматически. Отсюда вопрос, можно будет его на фронте скрыть, и если нет то хотелось бы совет, как я могу это реализовать

В методе пост я делаю проверку на соотвествие пользователя классу CompanyUser, которая вызывает ошибку 403, ее можно не проводить, тогда будет возникать ошибка 400, вызываемая несоотвествием поля уникакльности

В целом я провожу несколько проверок на instance пользователя, в разных http методах, мб вывести это в отдельный метод ?

Функионал для админа пока не готов, поэтому некоторые тесты закоментил
