### PR TITLE
Payments | Refactor payout

### DIFF
--- a/backend/payments/apps/external_payments/schemas.py
+++ b/backend/payments/apps/external_payments/schemas.py
@@ -77,10 +77,13 @@ class PayoutDestination(BaseModel):
     account_number: str
 
     class Config:
-        allow_population_by_field_name = True
+        populate_by_name = True
 
 
-class YookassaPayoutModel(BaseModel):
+class WithdrawModel(BaseModel):
     amount: YookassaMoneyDataClass
-    payout_destination_data: PayoutDestination
     user_uuid: UUID
+
+
+class YookassaPayoutModel(WithdrawModel):
+    payout_destination_data: PayoutDestination

--- a/backend/payments/apps/external_payments/services/payment_serivces/yookassa_service.py
+++ b/backend/payments/apps/external_payments/services/payment_serivces/yookassa_service.py
@@ -11,7 +11,7 @@ from apps.base.schemas import (
 )
 from apps.base.utils import change_balance
 from apps.external_payments import schemas
-from apps.external_payments.schemas import YookassaPayoutModel
+from apps.external_payments.schemas import PayoutDestination, WithdrawModel
 from apps.item_purchases.models import Invoice
 from apps.item_purchases.schemas import PurchaseItemsData
 from apps.payment_accounts.models import Account, BalanceChange, PayoutData
@@ -229,21 +229,25 @@ class YookassaPayOut(AbstractPayoutService):
         return Payout.create(payout_data)
 
     @staticmethod
-    def create_payout_data(payout_data: YookassaPayoutModel, developer_account: Account):
+    def create_payout_data(
+        withdraw_data: WithdrawModel,
+        developer_account: Account,
+        payout_data: PayoutDestination,
+    ):
         response = {
             'amount': {
-                'value': payout_data.amount.value,
-                'currency': payout_data.amount.currency.value,
+                'value': withdraw_data.amount.value,
+                'currency': withdraw_data.amount.currency.value,
             },
             'description': f'Выплата для {developer_account.user_uuid}',
         }
-        if payout_data.payout_destination_data.type_ == PayoutData.PayoutType.YOO_MONEY:
+        if payout_data.type_ == PayoutData.PayoutType.YOO_MONEY:
             response['payout_destination_data'] = {
-                'type': payout_data.payout_destination_data.type_.value,
-                'account_number': payout_data.payout_destination_data.account_number,
+                'type': payout_data.type_.value,
+                'account_number': payout_data.account_number,
             }
             return response
-        elif payout_data.payout_destination_data.type_ == PayoutData.PayoutType.BANK_CARD:
+        elif payout_data.type_ == PayoutData.PayoutType.BANK_CARD:
             # TODO add functionality to support bank card # noqa: T000
             #  https://yookassa.ru/developers/api#payout_object
             pass

--- a/backend/payments/apps/payment_accounts/serializers.py
+++ b/backend/payments/apps/payment_accounts/serializers.py
@@ -47,9 +47,8 @@ class PayoutDestination(serializers.Serializer):
         return super().to_internal_value(data)
 
 
-class PayoutSerializer(serializers.Serializer):
+class WithdrawSerializer(serializers.Serializer):
     amount = AmountPayoutSerializer()
-    payout_destination_data = PayoutDestination()
     user_uuid = serializers.UUIDField()
 
 

--- a/backend/payments/apps/payment_accounts/services/payout.py
+++ b/backend/payments/apps/payment_accounts/services/payout.py
@@ -4,7 +4,11 @@ from apps.base.exceptions import AttemptsLimitExceededError
 from apps.base.schemas import PaymentServices
 from apps.base.utils.change_balance import decrease_user_balance
 from apps.external_payments.models import BalanceServiceMap, PaymentService
-from apps.external_payments.schemas import YookassaPaymentStatuses, YookassaPayoutModel
+from apps.external_payments.schemas import (
+    PayoutDestination,
+    WithdrawModel,
+    YookassaPaymentStatuses,
+)
 from apps.external_payments.services.payment_serivces.yookassa_service import (
     YookassaPayOut,
 )
@@ -13,34 +17,47 @@ from apps.payment_accounts.exceptions import (
     NotPayoutDayError,
     NotValidAccountNumberError,
 )
-from apps.payment_accounts.models import Account, BalanceChange, Owner
+from apps.payment_accounts.models import Account, BalanceChange, Owner, PayoutData
 from django.conf import settings
+from django.forms import model_to_dict
 from django.shortcuts import get_object_or_404
 from yookassa.domain.exceptions import BadRequestError
 from yookassa.domain.response import PayoutResponse
 
 
 class PayoutProcessor:
-    def __init__(self, payout_data: YookassaPayoutModel):
-        self.payout_data = payout_data
+    def __init__(self, withdraw_data: WithdrawModel):
+        self.withdraw_data = withdraw_data
         self.developer_account: Account = get_object_or_404(
             Account,
-            user_uuid=self.payout_data.user_uuid,
+            user_uuid=self.withdraw_data.user_uuid,
         )
+        self.payout_data = self._get_pydantic_payout_data()
         # TODO add logic here to transform income bank card data to bank card token # noqa: T000
         # https://yookassa.ru
         # /docs/payment-solution/payouts/supplementary/collecting-data/bank-card-synonym-request
 
     def create_payout(self) -> str | None:
-        PayOutValidator(self.payout_data, self.developer_account).validate_payout()
+        PayOutValidator(self.withdraw_data, self.developer_account).validate_payout()
         response = self._request_service_payout()
         if response.status != YookassaPaymentStatuses.payout_succeeded.value:
             return 'Payment failed due to external reasons'
         self._add_to_db_payout_info(response)
         return 'Payout completed successfully'
 
+    def _get_pydantic_payout_data(self) -> PayoutDestination:
+        payout_data_obj = get_object_or_404(PayoutData, user_uuid=self.developer_account)
+        payout_data = model_to_dict(payout_data_obj)
+        # row below cuz pydantic currently not supporting several aliases
+        payout_data['type'] = payout_data['payout_type']
+        return PayoutDestination(**payout_data)
+
     def _request_service_payout(self) -> PayoutResponse | None:
-        data = YookassaPayOut.create_payout_data(self.payout_data, self.developer_account)
+        data = YookassaPayOut.create_payout_data(
+            self.withdraw_data,
+            self.developer_account,
+            self.payout_data,
+        )
         if data is None:
             raise NotImplementedError
         try:
@@ -55,7 +72,7 @@ class PayoutProcessor:
         )
         balance_change = decrease_user_balance(
             account=self.developer_account,
-            amount=self.payout_data.amount.value,
+            amount=self.withdraw_data.amount.value,
         )
         BalanceServiceMap.objects.create(
             service_id=payment_service,
@@ -66,7 +83,7 @@ class PayoutProcessor:
 
 
 class PayOutValidator:
-    def __init__(self, payout_model_data: YookassaPayoutModel, developer_account: Account):
+    def __init__(self, payout_model_data: WithdrawModel, developer_account: Account):
         self.payout_model_data = payout_model_data
         self.developer_account = developer_account
 

--- a/backend/payments/apps/payment_accounts/views.py
+++ b/backend/payments/apps/payment_accounts/views.py
@@ -1,7 +1,7 @@
 from apps.base.classes import DRFtoDataClassMixin
 from apps.base.exceptions import AttemptsLimitExceededError, DifferentStructureError
 from apps.base.utils.db_query import multiple_select_or_404
-from apps.external_payments.schemas import YookassaPayoutModel
+from apps.external_payments.schemas import WithdrawModel
 from django.forms import model_to_dict
 from django.http import Http404
 from django.shortcuts import get_object_or_404
@@ -77,15 +77,18 @@ class UserCreateDeleteView(
 
 
 class PayoutView(viewsets.ViewSet, DRFtoDataClassMixin):
-    serializer_class = serializers.PayoutSerializer
+    serializer_class = serializers.WithdrawSerializer
 
     def create(self, request, *args, **kwargs):
         try:
-            payout_data = self.convert_data(request, YookassaPayoutModel)
+            withdraw_data = self.convert_data(request, WithdrawModel)
         except DifferentStructureError:
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        try:
+            pre_payout_processor = PayoutProcessor(withdraw_data)
+        except Http404 as e:
+            return Response({'error': str(e)}, status=status.HTTP_404_NOT_FOUND)
 
-        pre_payout_processor = PayoutProcessor(payout_data)
         try:
             response = pre_payout_processor.create_payout()
         except (


### PR DESCRIPTION
…estination_data from it<

- YookassaPayoutModel to inherit from WithdrawModel representation for WithdrawSerializer
- PayoutProcessor fetch payout data from db for user request
- yookassa service create_payout_data with combination of WithdrawModel and PayoutDestination
- PayoutProcessor expect to receive WithdrawModel instance and later fetch PayoutData by himself not from serializer
- In PayoutView more expected 404 for more verbose error