### PR TITLE
Payments | Fix bug in swagger payment_commision

### DIFF
--- a/backend/payments/apps/payment_accounts/serializers.py
+++ b/backend/payments/apps/payment_accounts/serializers.py
@@ -12,7 +12,7 @@ from ..base.serializer import MoneySerializer
 from .models import Account, BalanceChange, Owner, PayoutData
 
 
-class PaymentCommissionSerializer(PaymentServiceSerializer):
+class CalculateCommissionSerializer(PaymentServiceSerializer):
     payment_amount = MoneyAmountSerializerField(
         validators=[MinValueValidator(0, message='Insufficient Funds')],
     )

--- a/backend/payments/apps/payment_accounts/views.py
+++ b/backend/payments/apps/payment_accounts/views.py
@@ -24,7 +24,7 @@ from .services.payout import PayoutProcessor
 
 
 class CalculatePaymentCommissionView(viewsets.ViewSet, DRFtoDataClassMixin):
-    serializer_class = serializers.PaymentCommissionSerializer
+    serializer_class = serializers.CalculateCommissionSerializer
 
     def create(self, request, *args, **kwargs):
         try:


### PR DESCRIPTION
There were two serializers with the same name(PaymentCommissionSerializer) in payment_accounts and external_payments.
- Renamed serializer from payment_accounts.